### PR TITLE
[Dual-ToR] decrease log-lovel from 'warning' to 'info' in order to avoid message flood in logs

### DIFF
--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -295,7 +295,7 @@ def check_mux_cable_port_type(logical_port_name, port_tbl, asic_index):
 
     (status, fvs) = port_tbl[asic_index].get(logical_port_name)
     if status is False:
-        helper_logger.log_warning(
+        helper_logger.log_info(
             "Could not retreive fieldvalue pairs for {}, inside config_db table {}".format(logical_port_name, port_tbl[asic_index].getTableName()))
         return (False, None)
 


### PR DESCRIPTION
Signed-off-by: Andriy Yurkiv <ayurkiv@nvidia.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Change loglevel from "warning" to "info" for logs in check_mux_cable_port_type() function in ycabled daemon

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
When Dual-ToR is configured, ycabled go through all interfaces and throws a "warning" each time when the interface has no MUX config. It causes flood in syslog and may confuse user because warnings related to interfaces that were newer related to MUX cables:
```
Feb  6 15:54:27.009848 r-tigon-17 WARNING pmon#ycabled: Could not retreive fieldvalue pairs for Ethernet144, inside config_db table MUX_CABLE
Feb  6 15:54:27.010251 r-tigon-17 WARNING pmon#ycabled: Could not retreive fieldvalue pairs for Ethernet72, inside config_db table MUX_CABLE
Feb  6 15:54:27.010651 r-tigon-17 WARNING pmon#ycabled: Could not retreive fieldvalue pairs for Ethernet156, inside config_db table MUX_CABLE
Feb  6 15:54:27.011055 r-tigon-17 WARNING pmon#ycabled: Could not retreive fieldvalue pairs for Ethernet164, inside config_db table MUX_CABLE
Feb  6 15:54:27.011452 r-tigon-17 WARNING pmon#ycabled: Could not retreive fieldvalue pairs for Ethernet176, inside config_db table MUX_CABLE
Feb  6 15:54:27.011855 r-tigon-17 WARNING pmon#ycabled: Could not retreive fieldvalue pairs for Ethernet24, inside config_db table MUX_CABLE
```


#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Check `/var/log/syslog`

#### Additional Information (Optional)
